### PR TITLE
Remove web-specific CI and add features

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,15 +16,11 @@ jobs:
     - uses: actions/checkout@master
     - name: Check formatting
       run: cargo fmt -- --check
-    - name: Clippy desktop
+    - name: Clippy
       run: cargo clippy -- -D warnings
-    - name: Clippy desktop with features enabled
+    - name: Clippy with all features
       run: cargo clippy --all-features -- -D warnings
-    - name: Check stdweb
-      if: matrix.os == 'macOS-latest'
-      run: cargo install cargo-web && cargo web check --features stdweb
-    - name: Clippy web-sys
-      if: matrix.os == 'macOS-latest'
-      run: cargo clippy --target wasm32-unknown-unknown --features web-sys -- -D warnings
+    - name: Clippy with doc features
+      run: cargo clippy --features image,rusttype
     - name: Examples
       run: cargo check --all-features --examples


### PR DESCRIPTION
elefont doesn't care if it's on web or not, so unlike the other
Quicksilver projects it doesn't need to worry about web / not web.
However, a few bugs have been caused by feature weirdness so check more
possibilities there