### PR TITLE
Add a method to replace textures on the cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.1.3
+- Add `FontCache::replace_texture`
+
 ## v0.1.2
 - Fix a compilation error without std but with unicode-normalization
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,17 @@ impl<T: Texture> FontCache<T> {
         self.render_string(string).map(|r| r.map(|_| ())).collect()
     }
 
+    /// Swap out the internal texture for another one
+    ///
+    /// This will clear the cache automatically, to avoid holding references to invalid areas of
+    /// the texture
+    pub fn replace_texture(&mut self, mut texture: T) -> T {
+        self.clear();
+        core::mem::swap(&mut self.cache.texture, &mut texture);
+
+        texture
+    }
+
     pub fn texture(&self) -> &T {
         &self.cache.texture
     }


### PR DESCRIPTION
Currently there's no way to replace a texture in-place, which can be
important to respond to cache pressure