### PR TITLE
Revamp the CI setup

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, nightly]
-        features: ['', '--all-features']
+        features: ['', '--all-features', "--features image,rusttype"]
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Check Formatting
       run: cargo fmt --all -- --check
 
-	test:
+  build:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,10 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, nightly]
-				features:
-          - ''
-          - '--all-features'
-          - '--features image,rusttype'
+				options: ['', '--all-features', '--features image,rusttype']
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:
@@ -29,7 +26,7 @@ jobs:
         components: clippy,rustfmt
     - uses: actions/checkout@master
     - name: Clippy
-      run: cargo test ${{ matrix.features }}
+      run: cargo test ${{ matrix.options }}
 
   clippy:
     strategy:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, nightly]
-				options: ['']
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, nightly]
-        features: []
+        features: ['', '--all-features']
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, nightly]
-				options: ['', '--all-features', '--features image,rusttype']
+				options: ['']
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, nightly]
-				features: ['', '--all-features', '--features image,rusttype']
+				features:
+          - ''
+          - '--all-features'
+          - '--features image,rusttype'
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable]
-				features: ['', '--all-features', "--features image,rusttype"]
+        features: ['', '--all-features', "--features image,rusttype"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,26 +1,45 @@
 name: Integration
 on: [push, pull_request]
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: stable
+        components: rustfmt
+    - name: Check Formatting
+      run: cargo fmt --all -- --check
+
+	test:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, nightly]
+				features: ['', --all-features, '--features image,rusttype']
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:
         rust-version: ${{ matrix.rust }}
         components: clippy,rustfmt
-        targets: wasm32-unknown-unknown
     - uses: actions/checkout@master
-    - name: Check formatting
-      run: cargo fmt -- --check
     - name: Clippy
-      run: cargo clippy -- -D warnings
-    - name: Clippy with all features
-      run: cargo clippy --all-features -- -D warnings
-    - name: Clippy with doc features
-      run: cargo clippy --features image,rusttype
-    - name: Examples
-      run: cargo check --all-features --examples
+      run: cargo test ${{ matrix.features }}
+
+  clippy:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        rust: [stable]
+				features: ['', --all-features, '--features image,rusttype']
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: hecrj/setup-rust-action@v1.2.0
+      with:
+        rust-version: ${{ matrix.rust }}
+        components: clippy,rustfmt
+    - uses: actions/checkout@master
+    - name: Clippy
+      run: cargo clippy ${{ matrix.features }} -- -D warnings

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,6 @@ jobs:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:
         rust-version: ${{ matrix.rust }}
-        components: clippy,rustfmt
     - uses: actions/checkout@master
     - name: Clippy
       run: cargo test ${{ matrix.options }}
@@ -39,7 +38,7 @@ jobs:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:
         rust-version: ${{ matrix.rust }}
-        components: clippy,rustfmt
+        components: clippy
     - uses: actions/checkout@master
     - name: Clippy
       run: cargo clippy ${{ matrix.features }} -- -D warnings

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,12 +13,12 @@ jobs:
       run: cargo fmt --all -- --check
 
   build:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, nightly]
-				features: ['', --all-features, '--features image,rusttype']
-    runs-on: ${{ matrix.os }}
+				features: ['', '--all-features', '--features image,rusttype']
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable]
-				features: ['', --all-features, '--features image,rusttype']
+				features: ['', '--all-features', '--features image,rusttype']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable]
-				features: ['', '--all-features', '--features image,rusttype']
+				features: ['', '--all-features', "--features image,rusttype"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, nightly]
+        features: []
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ hashbrown = { version = "0.7.1", default-features = false, features = ["ahash"] 
 image = { version = "0.22", default-features = false, optional = true }
 rusttype = { version = "0.8", optional = true }
 unicode-normalization = { version = "0.1.12", optional = true }
+
+[[example]]
+name = "render_image"
+required-features = ["image", "rusttype"]


### PR DESCRIPTION
Instead of running everything on all possible targets, only run fmt once
(it's not critical to check for operating system differences in a
formatter) and only run clippy on stable. Also, in addition to checking,
cargo test will actually run tests if any are available.