### PR TITLE
from_bytes became try_from_bytes in rusttypes

### DIFF
--- a/examples/render_image.rs
+++ b/examples/render_image.rs
@@ -5,7 +5,7 @@ use rusttype::Font;
 
 fn main() {
     let font_data = include_bytes!("DejaVuSans.ttf");
-    let font = Font::from_bytes(font_data as &[u8]).expect("Error constructing Font");
+    let font = Font::try_from_bytes(font_data as &[u8]).expect("Error constructing Font");
     let font = SizedFont::new(font, 24.0);
 
     let image = ImageBuffer::new(200, 200);


### PR DESCRIPTION
In rusttype's [release 0.8.3](https://docs.rs/rusttype/0.8.3/rusttype/struct.Font.html#method.from_bytes), the method was called `Font::from_bytes`. In the [current release 0.9.2](https://docs.rs/rusttype/0.9.2/rusttype/enum.Font.html#method.try_from_bytes), Font became an enum and features the method as `try_from_bytes`.

You specified release 0.9.2 in [Cargo.toml](https://github.com/ryanisaacg/elefont/blob/master/Cargo.toml#L23).